### PR TITLE
Fix typo in script path and don't apply sticky toc to just sticky

### DIFF
--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -206,13 +206,7 @@ class SetupAfterCache {
 			'remoteBasePath' => $GLOBALS[ 'chameleonRemotePath' ] . '/resources/js',
 			'group'          => 'skin.chameleon',
 			'skinScripts'    =>
-				[
-					'chameleon' => [
-						'hc-sticky/hc-sticky.js',
-						'Components/Modifications/sticky.js',
-						'Components/Modifications/stickytoc.js',
-					]
-				]
+				[ 'chameleon' => [ 'hc-sticky/hc-sticky.js', 'Components/Modifications/sticky.js' ] ]
 		];
 
 		$GLOBALS[ 'wgResourceModules' ][ 'skin.chameleon.stickytoc' ] = [
@@ -222,13 +216,13 @@ class SetupAfterCache {
 			'skinScripts'    =>
 				[
 					'chameleon' => [
-						'Components/Modifications/stickytoc.js',
+						'js/Components/Modifications/stickytoc.js',
 					]
 				],
 			'skinStyles'    =>
 				[
 					'chameleon' => [
-						'Components/Modifications/Stickytoc.less',
+						'styles/Components/Modifications/Stickytoc.less',
 					]
 				]
 		];


### PR DESCRIPTION
Make it so the "sticky" modification doesn't load sticky toc. This ensures backwards compatibility for users who want to use sticky mode but not sticky toc mode.

There was a typo in the path to load the stickytoc js and less file.

For context see https://github.com/ProfessionalWiki/chameleon/pull/386